### PR TITLE
feat: use monospace font for source views

### DIFF
--- a/ui/detail_view.go
+++ b/ui/detail_view.go
@@ -353,6 +353,7 @@ func (d *DetailView) createSource() *gtk.ScrolledWindow {
 	d.sourceView.SetEditable(false)
 	d.sourceView.SetWrapMode(gtk.WrapWord)
 	d.sourceView.SetShowLineNumbers(true)
+	d.sourceView.SetMonospace(true)
 	scrolledWindow.SetChild(d.sourceView)
 
 	windowSection := gio.NewMenu()
@@ -398,6 +399,7 @@ func (d *DetailView) showSaveDialog(parent *gtk.Window, object client.Object, cu
 	view.SetEditable(false)
 	view.SetWrapMode(gtk.WrapWord)
 	view.SetShowLineNumbers(false)
+	view.SetMonospace(true)
 
 	sw := gtk.NewScrolledWindow()
 	sw.SetChild(view)

--- a/ui/log_page.go
+++ b/ui/log_page.go
@@ -34,6 +34,7 @@ func NewLogPage(parent *gtk.Window, behavior *behavior.DetailBehavior, pod *core
 	view.SetEditable(false)
 	view.SetWrapMode(gtk.WrapWord)
 	view.SetShowLineNumbers(true)
+	view.SetMonospace(true)
 
 	scrolledWindow := gtk.NewScrolledWindow()
 	scrolledWindow.SetChild(view)


### PR DESCRIPTION
Without a fixed width font, logs can be harder to read and yaml indentation is also hard to judge.