### PR TITLE
metainfo: tweak brand colors

### DIFF
--- a/dev.skynomads.Seabird.appdata.xml
+++ b/dev.skynomads.Seabird.appdata.xml
@@ -18,8 +18,8 @@
   <url type="homepage">https://getseabird.github.io/</url>
   <developer_name>Seabird Project</developer_name>
   <branding>
-    <color type="primary" scheme_preference="light">#326ce5</color>
-    <color type="primary" scheme_preference="dark">#1b56d2</color>
+    <color type="primary" scheme_preference="light">#87a8ee</color>
+    <color type="primary" scheme_preference="dark">#87a8ee</color>
   </branding>
   <content_rating type="oars-1.1" />
   <releases>


### PR DESCRIPTION
Slightly tweak the shades of blue to ensure contrast with the app icon:

![image](https://github.com/getseabird/seabird/assets/1908896/5f044e8f-ca14-4a87-8cbc-955ca1a61de4)
