### PR TITLE
Simpler MetaInfo summary

### DIFF
--- a/dev.skynomads.Seabird.appdata.xml
+++ b/dev.skynomads.Seabird.appdata.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>dev.skynomads.Seabird</id>
   <name>Seabird</name>
-  <summary>A simple Kubernetes IDE for GNOME</summary>
+  <summary>Work with Kubernetes</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MPL-2.0</project_license>
   <description>


### PR DESCRIPTION
The summary is the only thing missing for this app to pass the [metadata review](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines/) on Flathub (the issues being the article at the start and mention of a specific target environment). This is just a random proposal, a few alternatives in case you like those better:

- Manage Kubernetes clusters
- Your Kubernetes companion